### PR TITLE
fix: remove error when using Python >= 3.11

### DIFF
--- a/llvm_diagnostics/messages.py
+++ b/llvm_diagnostics/messages.py
@@ -33,6 +33,9 @@ class Range:
         """Returns the last index of the Range"""
         return self.start + self.range
 
+    def __hash__(self):
+        return hash((self.start, self.range))
+
 
 @dataclass
 class __Message(Exception):  # pylint: disable=C0103


### PR DESCRIPTION
Make Range immutable by adding __hash__ function. Needed to avoid errors using Python >= 3.11 triggered by the following change: https://docs.python.org/3.11/whatsnew/3.11.html#dataclasses

The specific error one encounters using Python >= 3.11 is:

```
ValueError: mutable default <class 'llvm_diagnostics.messages.Range'> for field column_number is not allowed: use default_factory
```